### PR TITLE
Add new setting to display energy in total EU

### DIFF
--- a/src/recipeList.ts
+++ b/src/recipeList.ts
@@ -454,7 +454,7 @@ export class RecipeList {
                 totalEnergy += Math.ceil(amount)
             }
 
-            const formattedTotalEnergy  = new Intl.NumberFormat().format(totalEnergy);
+            const formattedTotalEnergy = formatAmount(totalEnergy);
 
             out += `<br>EU/t: ${formattedTotalEnergy}`
 

--- a/src/recipeList.ts
+++ b/src/recipeList.ts
@@ -445,20 +445,19 @@ export class RecipeList {
         };
 
         const renderEnergyItems = (energy: {[key:number]:number}) => {
-            let out = "";
             let totalEnergy = 0;
 
-            for (const [tier, amount] of Object.entries(energy)) {
+            const tierDetails = Object.entries(energy).map(([tier, amount]) => {
                 const tierInfo = voltageTier[parseInt(tier)];
-                out += `${tierInfo.name}: ${Math.ceil(100 * amount/tierInfo.voltage)/100}A<br>`;
-                totalEnergy += Math.ceil(amount)
-            }
+                const current = Math.ceil(100 * amount / tierInfo.voltage) / 100;
+                totalEnergy += Math.ceil(amount);
+
+                return `${tierInfo.name}: ${current}A`;
+            }).join('<br>');
 
             const formattedTotalEnergy = formatAmount(totalEnergy);
 
-            out += `<br>EU/t: ${formattedTotalEnergy}`
-
-            return out;
+            return `${tierDetails}<br><br>EU/t: ${formattedTotalEnergy}`;
         }
 
         return `

--- a/src/recipeList.ts
+++ b/src/recipeList.ts
@@ -446,10 +446,18 @@ export class RecipeList {
 
         const renderEnergyItems = (energy: {[key:number]:number}) => {
             let out = "";
+            let totalEnergy = 0;
+
             for (const [tier, amount] of Object.entries(energy)) {
                 const tierInfo = voltageTier[parseInt(tier)];
                 out += `${tierInfo.name}: ${Math.ceil(100 * amount/tierInfo.voltage)/100}A<br>`;
+                totalEnergy += Math.ceil(amount)
             }
+
+            const formattedTotalEnergy  = new Intl.NumberFormat().format(totalEnergy);
+
+            out += `<br>EU/t: ${formattedTotalEnergy}`
+
             return out;
         }
 


### PR DESCRIPTION
## Details
Add new setting to display energy in Total EU, for more clarity to compare setups and how much energy they use.

By default, will display by Voltage Tier (existing system)

New UI aspect:
![image](https://github.com/user-attachments/assets/30d0e9b0-5699-45b5-ae43-d81142c67446)

## Extra
Not sure who needs it, but it could be expanded into even further ways to display energy, tho i'm unsure of who needs that yet.