### PR TITLE
Fix EBF Muffler Hatch CO2 Output Calculation

### DIFF
--- a/src/machines.ts
+++ b/src/machines.ts
@@ -307,7 +307,7 @@ machines["Electric Blast Furnace"] = {
         for (let i=0; i<items.length; i++) {
             let item = items[i];
             if (item.type == RecipeIoType.FluidOutput && item.goods instanceof Fluid && 
-                (item.goods.name == "CO2 gas" || item.goods.name == "Sulfur Dioxide" || item.goods.name == "Carbon Monoxide")) {
+                (item.goods.name == "CO2 Gas" || item.goods.name == "Sulfur Dioxide" || item.goods.name == "Carbon Monoxide")) {
                 items = createEditableCopy(items);
                 items[i].amount = choices.muffler * item.amount * 0.125;
                 break;


### PR DESCRIPTION
This fixes a typo that caused the EBF to always output 100% of the possible **CO2 Gas**, ignoring the selected Muffler Hatch tier.

The following example has all Muffler Hatches set to LV (0%). It correctly calculates the **Sulfur Dioxide** and **Carbon Monoxide** outputs **(= 0L)**, but erroneously uses 100% for the calculation when the output is **CO2 Gas (= 1000L)**.

[Example: CO2 Gas vs Sulfur Dioxide vs Carbon Monoxide](https://shadowtheage.github.io/gtnh/#eJydUUtLw0AQ_itlzmtJWoNmoRdDaT1oKWgvIrJsptut-wibiVhD_O1uEgW9iHgbZr_XfNuCExaBw02z3xsMk7UgeZgUm9lkGYIPwKAKvmwk1cAfWlDel_V1GQmaq4CKUB64oqlFEprQTpOUp2mSXUSisL5xBHzesb8RZ1mWfuOl3SOD4D2tgm8q4C3QqeqzBpS6wic1rBkY7Z5jurZjgAYtus-sP9ARNw5DhvCeL016PDtmt5fF7tzmel28iblaLCLuxRsSCu80hhiCgTx4LbF3AOm1GfcJAztWFueuv_BXu_WuLlZ2e9qU2mxckcurV-u2_7aLxUhvjKhqjPp7YWpkXz85thXLqJFIOzUoWe12o8-gRdrivdOx5P4Fuu4DckatNg)

Old Version:
<img width="1050" height="572" alt="image" src="https://github.com/user-attachments/assets/efddc7e5-04f4-4831-b7c0-86c57b45a978" />

New Version:
<img width="1148" height="577" alt="image" src="https://github.com/user-attachments/assets/fd889ed1-150f-415b-89e5-7c30475cae7d" />

