### PR TITLE
[RFC] Provide overclock information as precise power and speed multipliers.

### DIFF
--- a/assets/styles/recipe-list.css
+++ b/assets/styles/recipe-list.css
@@ -222,6 +222,10 @@ select:hover {
     color: #ffffff;
 }
 
+.red-text {
+    color: #cc3333;
+}
+
 .io-items {
     display: flex;
     flex-wrap: wrap;

--- a/src/page.ts
+++ b/src/page.ts
@@ -210,6 +210,8 @@ export class RecipeModel extends RecipeGroupEntry
     multiblockCrafter:Item | null = null;
     recipeItems:RecipeInOut[] = [];
 
+    overclock?:OverclockResult;
+
     Visit(visitor: ModelObjectVisitor): void {
         visitor.VisitData(this, "type", this.type);
         visitor.VisitData(this, "recipeId", this.recipeId);
@@ -256,6 +258,18 @@ export class RecipeModel extends RecipeGroupEntry
         }
 
         this.choices = validatedChoices;
+    }
+
+    public getOverclockInfoText(): string {
+        if (!this.overclock || (this.overclock.overclockPower == 1 && this.overclock.overclockSpeed == 1 && this.overclock.perfectOverclocks == 0)) {
+            return 'No overclocks';
+        }
+
+        if (this.overclock.overclockPower == 1) {
+            return `${this.overclock.overclockPower}x power, ${this.overclock.overclockSpeed}x speed`;
+        } else {
+            return `<span class="text-small red-text">${this.overclock.overclockPower}x power</span>, ${this.overclock.overclockSpeed}x speed`;
+        }
     }
 
     public getFusionStartupCost(): number {

--- a/src/recipeList.ts
+++ b/src/recipeList.ts
@@ -323,8 +323,7 @@ export class RecipeList {
                                 let finalTier = initialTier + obj.overclockTiers;
                                 let initialTierName = voltageTier[initialTier].name;
                                 let finalTierName = voltageTier[finalTier].name;
-                                let overclocksText = obj.perfectOverclocks == 0 ? `${obj.overclockTiers} overclocks` : obj.perfectOverclocks == obj.overclockTiers ? `${obj.overclockTiers} perfect overclocks` : 
-                                    `${obj.overclockTiers} overclocks (${obj.perfectOverclocks} perfect)`;
+                                let overclocksText = obj.getOverclockInfoText();
                                 text = `${obj.parallels} parallels\n` +
                                        `${overclocksText} ${initialTier == finalTier ? `(${initialTierName})` : `(${initialTierName} → ${finalTierName})`}\n` +
                                        text + `\n${formatAmount(obj.overclockFactor)}x machine speed\n` +
@@ -568,7 +567,7 @@ export class RecipeList {
                 if (recipeModel.parallels > 1)
                     info.push(`${recipeModel.parallels} parallels`);
                 if (recipeModel.overclockTiers > 0)
-                    info.push(`${recipeModel.perfectOverclocks == 0 ? "OC" : recipeModel.perfectOverclocks == recipeModel.overclockTiers ? "Perfect OC" : "Mixed OC"} x${recipeModel.overclockTiers}`);
+                    info.push(recipeModel.getOverclockInfoText());
                 shortInfoContent += `<span class="text-small white-text">(${info.join(", ")})</span>`;
             }
 

--- a/src/solver.ts
+++ b/src/solver.ts
@@ -116,14 +116,15 @@ function PreProcessRecipe(recipeModel:RecipeModel, model:Model, collection:LinkC
         let parallels = Math.min(maxParallels, machineParallels);
         let tierDifference = recipeModel.voltageTier - gtRecipe.voltageTier;
         let overclockTiers = isSingleblock ? tierDifference : Math.min(tierDifference, Math.floor(Math.log2(maxParallels / parallels) / 2));
-        let {overclockSpeed, overclockPower, perfectOverclocks} = (machineInfo.customOverclock || calculateDefaultOverclocks)(recipeModel, overclockTiers);
+        let overclock = (machineInfo.customOverclock || calculateDefaultOverclocks)(recipeModel, overclockTiers);
         let speedModifier = GetParameter(machineInfo.speed, recipeModel);
         //console.log({machineParallels, maxParallels, parallels, overclockTiers, overclockSpeed, overclockPower, energyModifier, speedModifier});
-        recipeModel.overclockFactor = overclockSpeed * speedModifier * parallels;
-        recipeModel.powerFactor = overclockPower * energyModifier / speedModifier;
+        recipeModel.overclockFactor = overclock.overclockSpeed * speedModifier * parallels;
+        recipeModel.powerFactor = overclock.overclockPower * energyModifier / speedModifier;
         recipeModel.overclockTiers = overclockTiers;
-        recipeModel.perfectOverclocks = perfectOverclocks || 0;
+        recipeModel.perfectOverclocks = overclock.perfectOverclocks || 0;
         recipeModel.parallels = parallels;
+        recipeModel.overclock = overclock;
 
         if (recipeModel.fixedCrafterCount) {
             let crafterName = `fixed_${recipeModel.iid}`;


### PR DESCRIPTION
Considering how overclocks can be mixed, and not all machines do nice 4/4 perfect and 2/4 normal OCs, I think it would be more valuable to have precise values indicating power and speed change with respect to base.

<img width="747" height="424" alt="image" src="https://github.com/user-attachments/assets/01724367-58c6-4d5c-ba81-c7cc06a035fc" />

(ignore helium fusion being wrong, patch not applied)