### PR TITLE
Override user-selected voltage tier for fusion reactors.

### DIFF
--- a/src/machines.ts
+++ b/src/machines.ts
@@ -1206,12 +1206,13 @@ function getFusionTier(recipeModel:RecipeModel): number {
 function makeFusionOverclockCalculator(fusionTier:number, overclockMultiplier:number):(recipeModel:RecipeModel, overclockTiers:number) => OverclockResult {
     return function (recipeModel:RecipeModel, overclockTiers:number): OverclockResult {
         const recipeTier = Math.max(TIER_LUV, recipeModel.recipe?.gtRecipe?.voltageTier || 0, getFusionTier(recipeModel)+TIER_LUV-1);
-        const perfectOverclocks = Math.max(0, fusionTier - recipeTier);
+        const maxOverclocks = fusionTier - recipeTier;
+        const perfectOverclocks = Math.max(0, maxOverclocks);
         return {
             overclockSpeed:Math.pow(overclockMultiplier, perfectOverclocks),
             overclockPower:1,
             perfectOverclocks:perfectOverclocks,
-            overclockName:overclockMultiplier+"/"+overclockMultiplier+" OC x"+perfectOverclocks
+            overclockName:overclockMultiplier+"/"+overclockMultiplier+" OC x"+perfectOverclocks + ((perfectOverclocks == maxOverclocks) ? " (capped)" : "")
         };
     };
 }
@@ -1221,7 +1222,7 @@ machines["Fusion Control Computer Mark I"] = {
     power: 1,
     parallels: 1,
     customOverclock: makeFusionOverclockCalculator(TIER_LUV, 2),
-    info: "Min. energy hatch tier: LUV",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["Fusion Control Computer Mark II"] = {
@@ -1229,7 +1230,7 @@ machines["Fusion Control Computer Mark II"] = {
     power: 1,
     parallels: 1,
     customOverclock: makeFusionOverclockCalculator(TIER_ZPM, 2),
-    info: "Min. energy hatch tier: ZPM",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["Fusion Control Computer Mark III"] = {
@@ -1237,7 +1238,7 @@ machines["Fusion Control Computer Mark III"] = {
     power: 1,
     parallels: 1,
     customOverclock: makeFusionOverclockCalculator(TIER_UV, 2),
-    info: "Min. energy hatch tier: UV",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["FusionTech MK IV"] = {
@@ -1245,7 +1246,7 @@ machines["FusionTech MK IV"] = {
     power: 1,
     parallels: 1,
     customOverclock: makeFusionOverclockCalculator(TIER_UHV, 4),
-    info: "Min. energy hatch tier: UHV",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["FusionTech MK V"] = {
@@ -1253,15 +1254,16 @@ machines["FusionTech MK V"] = {
     power: 1,
     parallels: 1,
     customOverclock: makeFusionOverclockCalculator(TIER_UEV, 4),
-    info: "Min. energy hatch tier: UEV",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["Compact Fusion Computer MK-I Prototype"] = {
     speed: 1,
     power: 1,
     parallels: 64,
+    ignoreParallelLimit: true,
     customOverclock: makeFusionOverclockCalculator(TIER_LUV, 2),
-    info: "Min. energy hatch tier: LUV",
+    info: "NOTE: overrides voltage tier"
 };
 
 function getCompactFusionParallel(recipe:RecipeModel, tier:number) {
@@ -1273,30 +1275,34 @@ machines["Compact Fusion Computer MK-II"] = {
     speed: 1,
     power: 1,
     parallels: (recipe) => getCompactFusionParallel(recipe, 2),
+    ignoreParallelLimit: true,
     customOverclock: makeFusionOverclockCalculator(TIER_ZPM, 2),
-    info: "Min. energy hatch tier: ZPM",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["Compact Fusion Computer MK-III"] = {
     speed: 1,
     power: 1,
     parallels: (recipe) => getCompactFusionParallel(recipe, 3),
+    ignoreParallelLimit: true,
     customOverclock: makeFusionOverclockCalculator(TIER_UV, 2),
-    info: "Min. energy hatch tier: UV",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["Compact Fusion Computer MK-IV Prototype"] = {
     speed: 1,
     power: 1,
     parallels: (recipe) => getCompactFusionParallel(recipe, 4),
+    ignoreParallelLimit: true,
     customOverclock: makeFusionOverclockCalculator(TIER_UHV, 4),
-    info: "Min. energy hatch tier: UHV",
+    info: "NOTE: overrides voltage tier"
 };
 
 machines["Compact Fusion Computer MK-V"] = {
     speed: 1,
     power: 1,
     parallels: (recipe) => getCompactFusionParallel(recipe, 5),
+    ignoreParallelLimit: true,
     customOverclock: makeFusionOverclockCalculator(TIER_UEV, 4),
-    info: "Min. energy hatch tier: UEV",
+    info: "NOTE: overrides voltage tier"
 };

--- a/src/tests/__snapshots__/solver.test.ts.snap
+++ b/src/tests/__snapshots__/solver.test.ts.snap
@@ -656,7 +656,7 @@ exports[`Solver Processing Fusion Compact.gtnh should process without errors 1`]
     "crafterCount": 1,
     "id": "r~F6QidLWMO_CMaXkzw9l9ew==",
     "overclockFactor": 512,
-    "overclockName": "4/4 OC x1",
+    "overclockName": "4/4 OC x1 (capped)",
     "powerFactor": 1,
     "recipesPerMinute": 1280,
   },
@@ -664,7 +664,7 @@ exports[`Solver Processing Fusion Compact.gtnh should process without errors 1`]
     "crafterCount": 1,
     "id": "r~Ddxccy1nNXKyF69zWmk7DQ==",
     "overclockFactor": 64,
-    "overclockName": "4/4 OC x0",
+    "overclockName": "4/4 OC x0 (capped)",
     "powerFactor": 1,
     "recipesPerMinute": 128,
   },
@@ -674,12 +674,28 @@ exports[`Solver Processing Fusion Compact.gtnh should process without errors 1`]
 exports[`Solver Processing Fusion test.gtnh should process without errors 1`] = `
 [
   {
-    "crafterCount": 0.16666666666666669,
+    "crafterCount": 0.11979166666666667,
     "id": "r~DP9KmpbrNhK_f7XN8kGPuQ==",
     "overclockFactor": 64,
-    "overclockName": "4/4 OC x3",
+    "overclockName": "4/4 OC x3 (capped)",
     "powerFactor": 1,
-    "recipesPerMinute": 800,
+    "recipesPerMinute": 575,
+  },
+  {
+    "crafterCount": 1,
+    "id": "r~DP9KmpbrNhK_f7XN8kGPuQ==",
+    "overclockFactor": 1,
+    "overclockName": "2/2 OC x0 (capped)",
+    "powerFactor": 1,
+    "recipesPerMinute": 75,
+  },
+  {
+    "crafterCount": 1,
+    "id": "r~DP9KmpbrNhK_f7XN8kGPuQ==",
+    "overclockFactor": 2,
+    "overclockName": "2/2 OC x1 (capped)",
+    "powerFactor": 1,
+    "recipesPerMinute": 150,
   },
 ]
 `;

--- a/tests/Fusion Compact.gtnh
+++ b/tests/Fusion Compact.gtnh
@@ -10,7 +10,7 @@
       {
         "type": "recipe",
         "recipeId": "r~F6QidLWMO_CMaXkzw9l9ew==",
-        "voltageTier": 24,
+        "voltageTier": 6,
         "crafter": "i:gregtech:gt.blockmachines:32022",
         "choices": {},
         "fixedCrafterCount": 1
@@ -18,7 +18,7 @@
       {
         "type": "recipe",
         "recipeId": "r~Ddxccy1nNXKyF69zWmk7DQ==",
-        "voltageTier": 24,
+        "voltageTier": 7,
         "crafter": "i:gregtech:gt.blockmachines:32022",
         "choices": {},
         "fixedCrafterCount": 1

--- a/tests/Fusion test.gtnh
+++ b/tests/Fusion test.gtnh
@@ -16,6 +16,21 @@
         "voltageTier": 7,
         "crafter": "i:gregtech:gt.blockmachines:965",
         "choices": {}
+      },
+      {
+        "type": "recipe",
+        "recipeId": "r~DP9KmpbrNhK_f7XN8kGPuQ==",
+        "voltageTier": 3,
+        "choices": {},
+        "fixedCrafterCount": 1
+      },
+      {
+        "type": "recipe",
+        "recipeId": "r~DP9KmpbrNhK_f7XN8kGPuQ==",
+        "voltageTier": 3,
+        "crafter": "i:gregtech:gt.blockmachines:1194",
+        "choices": {},
+        "fixedCrafterCount": 1
       }
     ],
     "collapsed": false,
@@ -23,6 +38,6 @@
   },
   "settings": {
     "minVoltage": 0,
-    "timeUnit": "min"
+    "timeUnit": "sec"
   }
 }


### PR DESCRIPTION
To make the behaviour similar to the Assembly Line and Space Assembler. Rationale is that it's a pretty obscure edge case to have fusion reactors with less power than needed for all available recipes.

Also, similarly to Space Assembler, add suitable info text whenever the number of overclocks is capped (which is always, since we override the voltage)