### PR TITLE
Fix conversion of fusion startup cost to tier. It is not exponential.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,8 +24,18 @@ export type GtVoltageTier = {
 }
 
 export function getFusionTierByStartupCost(euToStart:number):number {
-    let rawTier = Math.log2(euToStart / 160e6) + 1;
-    return Math.min(5, Math.max(1, Math.ceil(rawTier)));
+    if (euToStart < 10_000_000 * 16)
+        return 1;
+    else if (euToStart < 20_000_000 * 16)
+        return 2;
+    else if (euToStart < 40_000_000 * 16)
+        return 3;
+    else if (euToStart < 320_000_000 * 16)
+        return 4;
+    else if (euToStart < 1_280_000_000 * 16)
+        return 5;
+    else
+        throw RangeError("Fusion startup cost is too high.");
 }
 
 export var voltageTier:GtVoltageTier[] = [


### PR DESCRIPTION
Merge after other PRs, as this may introduce annoying conflicts with the tests. The exporter also needs to be fixed because I think it uses the same formula. I used energy capacity values from https://gtnh.miraheze.org/wiki/Fusion_Reactor#Usage

fixes #73