### PR TITLE
Implement Eye of Harmony

### DIFF
--- a/assets/styles/recipe-list.css
+++ b/assets/styles/recipe-list.css
@@ -310,6 +310,15 @@ select:hover {
 .machine-choice-container {
     display: flex;
     align-items: center;
+
+    /* Allows wrapping between text and input control */
+    display: flex; 
+    flex-wrap: wrap; 
+
+    /* Indents second line if there's a split */
+    padding-left: 2em; 
+    text-indent: -2em; 
+
     gap: 4px;
 }
 

--- a/src/recipeList.ts
+++ b/src/recipeList.ts
@@ -675,7 +675,7 @@ export class RecipeList {
 
                 return `
                     <div class="machine-choice-container">
-                        <label>${choice.description}:</label>
+                        <label>${choice.description}: </label>
                         ${inputHtml}
                     </div>
                 `;


### PR DESCRIPTION
This is an attempt on implementing EoH, I'd like some feedback here.

- Power calculation is NOT implemented, would require more control and negative power
- Recipe tier is parsed from planet name as it's not available otherwise
- All EoH logic is implemented according to the tooltip and the wiki, however I cannot vouch for its correctness and cannot check with real values
- Due to the nature of EoH recipes can take a very long time, I think it would be appropriate to have a warning if recipe time is long, or perhaps even more information about expected recipe/success time.
    - There is a `console.info` like for debug purposes now
- #82 blocks this somewhat
- Rendering of `choice` inputs is modified to allow the browser to split them into a new line; an indent is added in such case to make it easier to discern which input corresponds to which label