### PR TITLE
Change wiki link to the more correct one

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <div class="menu-links">
                 <a href="#" id="nei-link">NEI</a>•
                 <a href="https://github.com/ShadowTheAge/gtnh/" target="_blank">Github</a>•
-                <a href="https://gtnh.miraheze.org/" target="_blank">Wiki</a>•
+                <a href="https://wiki.gtnewhorizons.com/" target="_blank">Wiki</a>•
                 <a href="https://docs.google.com/spreadsheets/d/1EIZtJU5eBbnUlrg7fD_ZyIzsr9sn4l4no9ek6M_iSVM" target="_blank">Spreadsheet</a>
             </div>
             <div class="menu-pages">


### PR DESCRIPTION
Changed it to https://wiki.gtnewhorizons.com/ from https://gtnh.miraheze.org/