### PR TITLE
feat(locale): define GameDataLocale baseline and fixed data.bin loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 .vscode/
 dist/
+src/data/

--- a/src/gameDataLocale.ts
+++ b/src/gameDataLocale.ts
@@ -1,0 +1,16 @@
+/**
+ * Game-data locale is intentionally independent from UI locale.
+ *
+ * Why this exists:
+ * - Non-English players often need mixed-language workflows.
+ * - UI text and in-game data (items/recipes/machine names) can be chosen separately.
+ *
+ * Typical scenarios:
+ * - UI in Chinese, game data in English (for wiki/modpack docs lookup).
+ * - UI in English, game data in Chinese.
+ * - Future bilingual content rendering (show primary + secondary language together).
+ *
+ * This parameter is only for game content language selection and must not be treated
+ * as a UI translation switch.
+ */
+export type GameDataLocale = "en" | "zh-CN";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
+import { applyDatabaseLocaleFont } from "./font.js";
+import type { GameDataLocale } from "./gameDataLocale.js";
+
 const loading = document.getElementById("loading")!;
 try {
     // Load the atlas image
     const atlas = new Image();
     atlas.src = "./data/atlas.webp";
+    
+    const gameDataLocale: GameDataLocale = "zh-CN";
+    applyDatabaseLocaleFont(gameDataLocale);
 
     // Load repository and data in parallel
     const [repositoryModule, response] = await Promise.all([


### PR DESCRIPTION
## Summary
- Introduce a minimal GameDataLocale baseline type for game-data language selection
- Move game-data locale rationale into index.ts
- Keep database loading fixed to ./data/data.bin
- Remove locale-based database file selection logic

## Notes
- This is the base PR for the locale stack.