### PR TITLE
feat(search): split locale-aware query into EN/ZH variants

### DIFF
--- a/src/searchQuery.ts
+++ b/src/searchQuery.ts
@@ -1,3 +1,5 @@
+type SearchDatabaseLocale = "en" | "zh-CN";
+
 const special:string = "09azAZ";
 const code0 = special.charCodeAt(0);
 const code9 = special.charCodeAt(1);
@@ -8,19 +10,49 @@ const codeZ = special.charCodeAt(5);
 const charCount = 26+10;
 const charOffset = 128-charCount;
 
-export class SearchQuery
-{
+function getSearchDatabaseLocaleParam(): string {
+    if (typeof localStorage !== "undefined") {
+        const fromStorage = localStorage.getItem("gtnh.gameLocale");
+        if (fromStorage && fromStorage.trim().length > 0) {
+            return fromStorage;
+        }
+    }
+
+    if (typeof window !== "undefined") {
+        const params = new URLSearchParams(window.location.search);
+        const fromQuery = params.get("gameLocale") ?? params.get("dbLocale");
+        if (fromQuery && fromQuery.trim().length > 0) {
+            return fromQuery;
+        }
+    }
+
+    return "zh-CN";
+}
+
+function normalizeSearchDatabaseLocale(locale: string): SearchDatabaseLocale {
+    return locale.toLowerCase().startsWith("zh") ? "zh-CN" : "en";
+}
+
+abstract class SearchQueryVariant {
     original:string;
     words:string[];
     indexBits:Int32Array;
     mod:string | null;
 
-    constructor(text:string)
-    {
+    constructor(text:string) {
         this.original = text;
-        this.words = text.match(/[A-Za-z0-9@]+/g) || [];
+        this.words = [];
         this.indexBits = new Int32Array(4);
         this.mod = null;
+    }
+
+    abstract Match(text: string | null): boolean;
+}
+
+class EnglishSearchQueryVariant extends SearchQueryVariant {
+    constructor(text:string) {
+        super(text);
+        this.words = text.match(/[A-Za-z0-9@]+/g) || [];
 
         for (var i=0; i<this.words.length; i++)
         {
@@ -58,7 +90,7 @@ export class SearchQuery
         }
     }
 
-    SetBit(bitId:number)
+    private SetBit(bitId:number)
     {
         var element = Math.trunc(bitId / 32);
         var bit = 1 << (bitId % 32);
@@ -76,5 +108,68 @@ export class SearchQuery
                 return false;
         }
         return true;
+    }
+}
+
+class ChineseSearchQueryVariant extends SearchQueryVariant {
+    constructor(text:string) {
+        super(text);
+        this.words = text.match(/[@\p{L}\p{N}_]+/gu) || [];
+
+        for (var i=0; i<this.words.length; i++)
+        {
+            var word = this.words[i];
+            if (word.startsWith('@')) {
+                this.mod = word.substring(1).toLowerCase();
+                this.words.splice(i, 1);
+                i--;
+                continue;
+            }
+            this.words[i] = word.toLowerCase();
+        }
+    }
+
+    Match(text: string | null): boolean
+    {
+        if (text === null)
+            return false;
+
+        const normalizedText = ChineseSearchQueryVariant.NormalizeForSpaceInsensitiveMatch(text);
+        for (const word of this.words) {
+            const normalizedWord = ChineseSearchQueryVariant.NormalizeForSpaceInsensitiveMatch(word);
+            if (normalizedWord.length > 0 && !normalizedText.includes(normalizedWord))
+                return false;
+        }
+        return true;
+    }
+
+    private static NormalizeForSpaceInsensitiveMatch(text:string):string
+    {
+        return text.toLowerCase().replace(/\s+/g, "");
+    }
+}
+
+export class SearchQuery
+{
+    original:string;
+    words:string[];
+    indexBits:Int32Array;
+    mod:string | null;
+    private variant:SearchQueryVariant;
+
+    constructor(text:string, databaseLocale:SearchDatabaseLocale = normalizeSearchDatabaseLocale(getSearchDatabaseLocaleParam()))
+    {
+        this.variant = databaseLocale === "zh-CN"
+            ? new ChineseSearchQueryVariant(text)
+            : new EnglishSearchQueryVariant(text);
+        this.original = this.variant.original;
+        this.words = this.variant.words;
+        this.indexBits = this.variant.indexBits;
+        this.mod = this.variant.mod;
+    }
+
+    Match(text: string | null): boolean
+    {
+        return this.variant.Match(text);
     }
 }


### PR DESCRIPTION
## Summary
- Split search behavior into English and Chinese variants
- Keep search locale detection self-contained in searchQuery.ts
- Add space-insensitive Chinese search handling

## Notes
- Designed to be decoupled from gameDataLocale internals.
- Merge after base PR.