### PR TITLE
feat(font): add locale font profiles with fallback formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 .vscode/
 dist/
+src/data/

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -1,0 +1,18 @@
+Embedded UI font placement
+
+If you want to use an embedded CJK UI font instead of relying on system fonts,
+put one of these files in this folder:
+
+- ui-font.woff2
+- ui-font.ttf
+
+The frontend CSS already looks for them via the ProjectUI font-family in:
+
+- assets/styles/general.css
+
+Recommended fonts:
+
+- Noto Sans SC / Noto Sans CJK SC
+- Source Han Sans SC
+
+Prefer woff2 if you can subset the font, because full CJK fonts can be very large.

--- a/assets/styles/general.css
+++ b/assets/styles/general.css
@@ -1,18 +1,60 @@
 @font-face {
     font-family:'Minecraftia';
     src: url('./../fonts/F77MinecraftRegular-0VYv.ttf');
+    /* Keep pixel-style font for Latin UI only; CJK should always fall back to secondary fonts. */
+    unicode-range:
+        U+0000-00FF,
+        U+0100-024F,
+        U+1E00-1EFF,
+        U+2000-206F,
+        U+20A0-20CF;
+}
+
+@font-face {
+    font-family:'ProjectUI';
+    src:
+        local('Noto Sans CJK SC'),
+        local('Noto Sans SC'),
+        local('Microsoft YaHei UI'),
+        local('Microsoft YaHei'),
+        local('PingFang SC'),
+        local('Hiragino Sans GB'),
+        local('Source Han Sans SC'),
+        local('SimSun'),
+        local('NSimSun'),
+        local('Arial Unicode MS'),
+        local('Segoe UI Symbol'),
+        url('./../fonts/ui-font.woff2') format('woff2'),
+        url('./../fonts/ui-font.ttf') format('truetype');
+    font-display: swap;
+}
+
+:root {
+    --font-ui-primary: "Minecraftia";
+    --font-ui-secondary-zh: "MiSans", "ProjectUI", "Noto Sans CJK SC", "Noto Sans SC", "Microsoft YaHei UI", "Microsoft YaHei", "PingFang SC", "Hiragino Sans GB", "Source Han Sans SC", "SimSun", "NSimSun", "Arial Unicode MS", "Segoe UI Symbol", sans-serif;
+    --font-ui-secondary-latin: "Segoe UI", "Helvetica Neue", "Arial", "Noto Sans", "Liberation Sans", sans-serif;
+    --font-ui-secondary: var(--font-ui-secondary-latin);
+    --font-ui: var(--font-ui-primary), var(--font-ui-secondary);
+    --font-ui-size: 16px;
+    --font-ui-line-height: 22px;
+    --font-ui-control-size: 16px;
+    --font-ui-control-line-height: 22px;
+    --font-ui-input-line-height: 16px;
+    --font-ui-small-size: 8px;
+    --font-ui-small-line-height: 8px;
+    --font-ui-small-word-spacing: 1px;
 }
 
 body {
-    font-family:'Minecraftia', sans-serif;
-    -webkit-font-smoothing: never;
-    font-smooth: never;
-    font-kerning: none;
-    image-rendering: pixelated;
-    text-rendering: geometricPrecision;
-    font-size: 16px;
+    font-family: var(--font-ui);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-kerning: normal;
+    image-rendering: auto;
+    text-rendering: optimizeLegibility;
+    font-size: var(--font-ui-size);
     margin: 0px;
-    line-height: 22px;
+    line-height: var(--font-ui-line-height);
     color: white;
     background-color: #212121;
     word-break: break-word;
@@ -24,15 +66,15 @@ body {
 
 .text-small
 {
-    font-size: 8px;
-    line-height: 8px;
-    word-spacing: 1px;
+    font-size: var(--font-ui-small-size);
+    line-height: var(--font-ui-small-line-height);
+    word-spacing: var(--font-ui-small-word-spacing);
 }
 
 button {
-    font-family: 'Minecraftia', sans-serif;
-    font-size: 16px;
-    line-height: 22px;
+    font-family: var(--font-ui);
+    font-size: var(--font-ui-control-size);
+    line-height: var(--font-ui-control-line-height);
     border: 2px solid;
     border-bottom-width: 4px;
     border-color: #A8A8A8 #565656 #565656 #A8A8A8;
@@ -63,10 +105,10 @@ button:hover {
 }
 
 input {
-    font-family:'Minecraftia', sans-serif;
+    font-family: var(--font-ui);
     background-color: #8B8B8B;
-    font-size: 16px;
-    line-height: 16px;
+    font-size: var(--font-ui-control-size);
+    line-height: var(--font-ui-input-line-height);
     color: white;
     text-shadow: 2px 2px #342C34;
     pointer-events: all;
@@ -74,7 +116,7 @@ input {
     border-width: 2px;
     border-color: #373737 #ffffff #ffffff #373737;
     margin: 2px;
-    height: 16;
+    height: var(--font-ui-input-line-height);
 }
 
 input:focus {

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,0 +1,143 @@
+import type { GameDataLocale } from "./gameDataLocale.js";
+
+const zhSecondaryFontStack = `var(--font-ui-secondary-zh)`;
+const latinSecondaryFallback = `var(--font-ui-secondary-latin)`;
+
+type FontFormatConfig = {
+    uiSizePx?: number;
+    uiLineHeightPx?: number;
+    controlSizePx?: number;
+    controlLineHeightPx?: number;
+    inputLineHeightPx?: number;
+    smallSizePx?: number;
+    smallLineHeightPx?: number;
+    smallWordSpacingPx?: number;
+};
+
+type FontLocaleProfile = {
+    secondaryFontStack?: string;
+    systemFontCandidates?: string[];
+    format?: FontFormatConfig;
+};
+
+const defaultFontFormat: Required<FontFormatConfig> = {
+    uiSizePx: 16,
+    uiLineHeightPx: 22,
+    controlSizePx: 16,
+    controlLineHeightPx: 22,
+    inputLineHeightPx: 16,
+    smallSizePx: 8,
+    smallLineHeightPx: 8,
+    smallWordSpacingPx: 1,
+};
+
+const fontProfiles: Record<string, FontLocaleProfile> = {
+    default: {},
+    en: {},
+    "zh-cn": {
+        secondaryFontStack: `"MiSans", ${zhSecondaryFontStack}`,
+        format: {
+            uiSizePx: 18,
+            uiLineHeightPx: 24,
+            controlSizePx: 18,
+            controlLineHeightPx: 24,
+            inputLineHeightPx: 18,
+            smallSizePx: 9,
+            smallLineHeightPx: 9,
+            smallWordSpacingPx: 1,
+        },
+    },
+    ja: {
+        systemFontCandidates: ["Yu Gothic UI", "Meiryo", "Noto Sans JP"],
+    },
+    ko: {
+        systemFontCandidates: ["Malgun Gothic", "Apple SD Gothic Neo", "Noto Sans KR"],
+    },
+    ar: {
+        systemFontCandidates: ["Segoe UI", "Tahoma", "Noto Naskh Arabic"],
+    },
+    ru: {
+        systemFontCandidates: ["Segoe UI", "Arial", "Noto Sans"],
+    },
+    uk: {
+        systemFontCandidates: ["Segoe UI", "Arial", "Noto Sans"],
+    },
+};
+
+function normalizeLocaleKey(locale: string): string {
+    return locale.toLowerCase();
+}
+
+function resolveLocaleProfile(locale: string): FontLocaleProfile {
+    const normalized = normalizeLocaleKey(locale);
+    if (fontProfiles[normalized]) {
+        return fontProfiles[normalized];
+    }
+
+    const prefix = normalized.split("-")[0];
+    if (fontProfiles[prefix]) {
+        return fontProfiles[prefix];
+    }
+
+    return fontProfiles.default;
+}
+
+function resolveFontFormat(locale: string): Required<FontFormatConfig> {
+    const profileFormat = resolveLocaleProfile(locale).format ?? {};
+    return {
+        ...defaultFontFormat,
+        ...profileFormat,
+    };
+}
+
+function browserDefaultLanguageFontCandidates(): string[] {
+    const language = normalizeLocaleKey(navigator.language ?? "en");
+    const profile = resolveLocaleProfile(language);
+    return profile.systemFontCandidates ?? ["Segoe UI", "Helvetica Neue", "Arial", "Noto Sans", "Roboto", "Ubuntu"];
+}
+
+function pickAvailableSystemFont(fontCandidates: string[]): string | null {
+    if (!document.fonts?.check) {
+        return null;
+    }
+
+    for (const candidate of fontCandidates) {
+        if (document.fonts.check(`16px \"${candidate}\"`)) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
+function applyFontFormat(locale: string): void {
+    const rootStyle = document.documentElement.style;
+    const format = resolveFontFormat(locale);
+    rootStyle.setProperty("--font-ui-size", `${format.uiSizePx}px`);
+    rootStyle.setProperty("--font-ui-line-height", `${format.uiLineHeightPx}px`);
+    rootStyle.setProperty("--font-ui-control-size", `${format.controlSizePx}px`);
+    rootStyle.setProperty("--font-ui-control-line-height", `${format.controlLineHeightPx}px`);
+    rootStyle.setProperty("--font-ui-input-line-height", `${format.inputLineHeightPx}px`);
+    rootStyle.setProperty("--font-ui-small-size", `${format.smallSizePx}px`);
+    rootStyle.setProperty("--font-ui-small-line-height", `${format.smallLineHeightPx}px`);
+    rootStyle.setProperty("--font-ui-small-word-spacing", `${format.smallWordSpacingPx}px`);
+}
+
+export function applyDatabaseLocaleFont(databaseLocale: GameDataLocale): void {
+    const rootStyle = document.documentElement.style;
+    document.documentElement.dataset.dbLocale = databaseLocale;
+    applyFontFormat(databaseLocale);
+
+    if (databaseLocale === "zh-CN") {
+        rootStyle.setProperty("--font-ui-secondary", resolveLocaleProfile(databaseLocale).secondaryFontStack ?? zhSecondaryFontStack);
+        return;
+    }
+
+    const selected = pickAvailableSystemFont(browserDefaultLanguageFontCandidates());
+    if (selected) {
+        rootStyle.setProperty("--font-ui-secondary", `\"${selected}\", ${latinSecondaryFallback}`);
+        return;
+    }
+
+    rootStyle.setProperty("--font-ui-secondary", latinSecondaryFallback);
+}

--- a/src/gameDataLocale.ts
+++ b/src/gameDataLocale.ts
@@ -1,0 +1,16 @@
+/**
+ * Game-data locale is intentionally independent from UI locale.
+ *
+ * Why this exists:
+ * - Non-English players often need mixed-language workflows.
+ * - UI text and in-game data (items/recipes/machine names) can be chosen separately.
+ *
+ * Typical scenarios:
+ * - UI in Chinese, game data in English (for wiki/modpack docs lookup).
+ * - UI in English, game data in Chinese.
+ * - Future bilingual content rendering (show primary + secondary language together).
+ *
+ * This parameter is only for game content language selection and must not be treated
+ * as a UI translation switch.
+ */
+export type GameDataLocale = "en" | "zh-CN";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
+import { applyDatabaseLocaleFont } from "./font.js";
+import type { GameDataLocale } from "./gameDataLocale.js";
+
 const loading = document.getElementById("loading")!;
 try {
     // Load the atlas image
     const atlas = new Image();
     atlas.src = "./data/atlas.webp";
+    
+    const gameDataLocale: GameDataLocale = "zh-CN";
+    applyDatabaseLocaleFont(gameDataLocale);
 
     // Load repository and data in parallel
     const [repositoryModule, response] = await Promise.all([


### PR DESCRIPTION
## Summary
- Add locale-specific font profiles and formatting rules
- Apply font selection and fallback handling via font module
- Include related style/font asset updates

## Notes
- Depends on locale base context for this PR stack.
- Merge last in this sequence.