### PR TITLE
Updated itemIcon.ts mobile touch behavior

### DIFF
--- a/src/itemIcon.ts
+++ b/src/itemIcon.ts
@@ -1,6 +1,6 @@
 import { Repository, Goods, OreDict, RecipeObject } from "./repository.js";
 import { NeiSelect, ShowNei, ShowNeiMode } from "./nei.js";
-import { ShowTooltip, HideTooltip, IsHovered } from "./tooltip.js";
+import { ShowTooltip, HideTooltip, IsHovered, currentTooltipElement } from "./tooltip.js";
 
 let globalIndex = 0;
 let oredictElements: IconBox[] = [];
@@ -20,6 +20,36 @@ window.setInterval(() => {
 }, 500);
 
 let highlightStyle: HTMLStyleElement = document.getElementById('item-icon-highlight-style') as HTMLStyleElement;
+
+function CloseCurrentTooltip() {
+    if (currentTooltipElement) {
+        HideTooltip(currentTooltipElement);
+    }
+
+    if (highlightStyle) {
+        highlightStyle.textContent = "";
+    }
+}
+
+function CloseTooltipIfOutside(event: Event) {
+    const target = event.target as HTMLElement | null;
+
+    if (!target) return;
+    if (target.closest("item-icon")) return;
+    if (target.closest("#tooltip")) return;
+
+    CloseCurrentTooltip();
+}
+
+document.addEventListener("touchstart", CloseTooltipIfOutside, { passive: true, capture: true });
+document.addEventListener("mousedown", CloseTooltipIfOutside, { passive: true, capture: true });
+document.addEventListener("click", CloseTooltipIfOutside, { passive: true, capture: true });
+
+document.addEventListener("keydown", (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+        CloseCurrentTooltip();
+    }
+});
 
 export class IconBox extends HTMLElement {
     public obj: RecipeObject | null = null;
@@ -149,7 +179,7 @@ export class IconBox extends HTMLElement {
             return;
         }
 
-        if (action) return;
+        if (action && action !== "item_icon_click") return;
 
         ShowNei(this.obj, ShowNeiMode.Production, null);
     }
@@ -162,7 +192,7 @@ export class IconBox extends HTMLElement {
             return;
         }
 
-        if (action) return;
+        if (action && action !== "item_icon_click") return;
 
         ShowNei(this.obj, ShowNeiMode.Consumption, null);
     }

--- a/src/itemIcon.ts
+++ b/src/itemIcon.ts
@@ -1,20 +1,17 @@
-import { Repository, Goods, Item, Fluid, OreDict, RecipeObject } from "./repository.js";
-import { NeiSelect, ShowNei, ShowNeiContext, ShowNeiMode } from "./nei.js";
+import { Repository, Goods, OreDict, RecipeObject } from "./repository.js";
+import { NeiSelect, ShowNei, ShowNeiMode } from "./nei.js";
 import { ShowTooltip, HideTooltip, IsHovered } from "./tooltip.js";
 
-// Global cycling state
 let globalIndex = 0;
 let oredictElements: IconBox[] = [];
 
-// Global actions map
 export const actions: { [key: string]: string } = {
-    "item_icon_click": "Left/Right click to add recipe",
-    "select": "Click to select",
-    "toggle_link_ignore": "Click to toggle link ignore",
-    "crafter_click": "Click to select another crafter"
+    "item_icon_click": "Tap: recipe | Double tap: usage | Hold: name",
+    "select": "Tap to select",
+    "toggle_link_ignore": "Tap to toggle link ignore",
+    "crafter_click": "Tap to select another crafter"
 };
 
-// Start global cycle once
 window.setInterval(() => {
     globalIndex++;
     for (const element of oredictElements) {
@@ -24,43 +21,173 @@ window.setInterval(() => {
 
 let highlightStyle: HTMLStyleElement = document.getElementById('item-icon-highlight-style') as HTMLStyleElement;
 
-export class IconBox extends HTMLElement
-{
-    public obj:RecipeObject | null = null;
+export class IconBox extends HTMLElement {
+    public obj: RecipeObject | null = null;
 
-    constructor()
-    {
+    private touchTimer: number | null = null;
+    private tapTimer: number | null = null;
+    private lastTapTime = 0;
+    private lastTouchTime = 0;
+    private longPressShown = false;
+    private touchMoved = false;
+    private touchStartX = 0;
+    private touchStartY = 0;
+
+    constructor() {
         super();
-        
+
         this.addEventListener("mouseenter", () => {
-            const obj = this.GetDisplayObject();
-            if (obj) {
-                const actionType = this.getAttribute('data-action');
-                const actionText = actionType ? actions[actionType] : undefined;
-                ShowTooltip(this, {
-                    goods: obj,
-                    action: actionText ?? "Left/Right click to view Production/Consumption for this item"
-                });
-                
-                this.UpdateHighlightStyle();
-            }
+            this.ShowNameTooltip("Left click: recipe | Right click: usage");
         });
-        
+
         this.addEventListener("mouseleave", () => {
             highlightStyle.textContent = '';
         });
-        
-        this.addEventListener('contextmenu', this.RightClick);
-        this.addEventListener('click', this.LeftClick);
+
+        this.addEventListener("touchstart", (event: TouchEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            this.lastTouchTime = Date.now();
+            this.longPressShown = false;
+            this.touchMoved = false;
+
+            const t = event.touches[0];
+            this.touchStartX = t.clientX;
+            this.touchStartY = t.clientY;
+
+            this.ClearTouchTimer();
+
+            this.touchTimer = window.setTimeout(() => {
+                this.longPressShown = true;
+                this.ShowNameTooltip("Hold: name | Tap: recipe | Double tap: usage");
+            }, 450);
+        }, { passive: false, capture: true });
+
+        this.addEventListener("touchmove", (event: TouchEvent) => {
+            const t = event.touches[0];
+            const dx = Math.abs(t.clientX - this.touchStartX);
+            const dy = Math.abs(t.clientY - this.touchStartY);
+
+            if (dx > 10 || dy > 10) {
+                this.touchMoved = true;
+                this.ClearTouchTimer();
+            }
+        }, { passive: true, capture: true });
+
+        this.addEventListener("touchend", (event: TouchEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            this.lastTouchTime = Date.now();
+            this.ClearTouchTimer();
+
+            if (this.touchMoved) return;
+            if (this.longPressShown) return;
+
+            const now = Date.now();
+
+            if (now - this.lastTapTime < 320) {
+                if (this.tapTimer !== null) {
+                    window.clearTimeout(this.tapTimer);
+                    this.tapTimer = null;
+                }
+
+                this.lastTapTime = 0;
+                this.MobileUsage();
+                return;
+            }
+
+            this.lastTapTime = now;
+
+            if (this.tapTimer !== null) {
+                window.clearTimeout(this.tapTimer);
+            }
+
+            this.tapTimer = window.setTimeout(() => {
+                this.tapTimer = null;
+                this.MobileProduction();
+            }, 260);
+        }, { passive: false, capture: true });
+
+        this.addEventListener("contextmenu", (event: MouseEvent) => {
+            if (Date.now() - this.lastTouchTime < 1500) {
+                event.preventDefault();
+                event.stopPropagation();
+                this.ShowNameTooltip("Hold: name | Tap: recipe | Double tap: usage");
+                return;
+            }
+
+            this.RightClick(event);
+        }, true);
+
+        this.addEventListener("click", (event: MouseEvent) => {
+            if (Date.now() - this.lastTouchTime < 1000) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+
+            this.LeftClick();
+        }, true);
+
         this.UpdateIconId();
+    }
+
+    private ClearTouchTimer() {
+        if (this.touchTimer !== null) {
+            window.clearTimeout(this.touchTimer);
+            this.touchTimer = null;
+        }
+    }
+
+    private MobileProduction() {
+        let action = this.CustomAction();
+
+        if (action === "select") {
+            NeiSelect(this.GetDisplayObject() as Goods);
+            return;
+        }
+
+        if (action) return;
+
+        ShowNei(this.obj, ShowNeiMode.Production, null);
+    }
+
+    private MobileUsage() {
+        let action = this.CustomAction();
+
+        if (action === "select") {
+            NeiSelect(this.GetDisplayObject() as Goods);
+            return;
+        }
+
+        if (action) return;
+
+        ShowNei(this.obj, ShowNeiMode.Consumption, null);
+    }
+
+    private ShowNameTooltip(actionOverride?: string) {
+        const obj = this.GetDisplayObject();
+
+        if (obj) {
+            const actionType = this.getAttribute('data-action');
+            const actionText = actionType ? actions[actionType] : undefined;
+
+            ShowTooltip(this, {
+                goods: obj,
+                action: actionText ?? actionOverride ?? "Item tooltip"
+            });
+
+            this.UpdateHighlightStyle();
+        }
     }
 
     private StartOredictCycle(oredict: OreDict) {
         if (!oredict || oredict.items.length === 0) return;
-        
+
         this.UpdateIconId();
-        
-        // Add to global cycle if not already there
+
         if (!oredictElements.includes(this)) {
             oredictElements.push(this);
         }
@@ -68,6 +195,7 @@ export class IconBox extends HTMLElement
 
     private StopOredictCycle() {
         const index = oredictElements.indexOf(this);
+
         if (index > -1) {
             oredictElements.splice(index, 1);
         }
@@ -75,6 +203,7 @@ export class IconBox extends HTMLElement
 
     private UpdateHighlightStyle() {
         const currentIconId = this.obj?.id;
+
         if (currentIconId && !this.classList.contains('item-icon-grid')) {
             highlightStyle.textContent = `
                 item-icon[data-id="${currentIconId}"] {
@@ -87,17 +216,17 @@ export class IconBox extends HTMLElement
 
     UpdateIconId() {
         const obj = this.GetDisplayObject();
+
         if (obj) {
             const iconId = obj.iconId;
             const ix = iconId % 256;
             const iy = Math.floor(iconId / 256);
+
             this.style.setProperty('--pos-x', `${ix * -32}px`);
             this.style.setProperty('--pos-y', `${iy * -32}px`);
-            
-            // Update tooltip if this element is currently being hovered
+
             if (IsHovered(this)) {
-                ShowTooltip(this, { goods: obj });
-                this.UpdateHighlightStyle();
+                this.ShowNameTooltip();
             }
         }
     }
@@ -109,7 +238,8 @@ export class IconBox extends HTMLElement
     attributeChangedCallback(name: string, oldValue: string, newValue: string) {
         if (name === 'data-id') {
             this.StopOredictCycle();
-            this.obj = Repository.current.GetById<RecipeObject>(newValue);
+            this.obj = Repository.current.GetById(newValue);
+
             if (this.obj instanceof OreDict) {
                 this.StartOredictCycle(this.obj);
             } else {
@@ -118,8 +248,7 @@ export class IconBox extends HTMLElement
         }
     }
 
-    GetDisplayObject():Goods | null
-    {
+    GetDisplayObject(): Goods | null {
         if (this.obj instanceof Goods) {
             return this.obj;
         }
@@ -131,37 +260,33 @@ export class IconBox extends HTMLElement
         return null;
     }
 
-    disconnectedCallback()
-    {
+    disconnectedCallback() {
         this.StopOredictCycle();
         HideTooltip(this);
+
         if (IsHovered(this)) {
             highlightStyle.textContent = '';
         }
     }
 
-    private CustomAction():string | null
-    {
+    private CustomAction(): string | null {
         return this.getAttribute('data-action');
     }
 
-    RightClick(event:any)
-    {
-        if (this.CustomAction())
-            return;
-        if (event.ctrlKey || event.metaKey)
-            return;
+    RightClick(event: any) {
+        if (this.CustomAction()) return;
+        if (event.ctrlKey || event.metaKey) return;
+
         event.preventDefault();
         ShowNei(this.obj, ShowNeiMode.Consumption, null);
     }
 
-    LeftClick()
-    {
+    LeftClick() {
         let action = this.CustomAction();
-        if (action === "select")
-            NeiSelect(this.GetDisplayObject() as Goods);
-        if (action)
-            return;
+
+        if (action === "select") NeiSelect(this.GetDisplayObject() as Goods);
+        if (action) return;
+
         ShowNei(this.obj, ShowNeiMode.Production, null);
     }
 }


### PR DESCRIPTION
Updates item icon controls to work better on mobile/touch devices.

Problem:
- Desktop users can hover item icons to see the item/fluid name.
- On mobile, hover is not available.
- Long-press can trigger context menu / usage behavior instead of showing the tooltip.

Updated behavior:
- Desktop hover: show tooltip/name
- Desktop left click: production recipe
- Desktop right click: usage recipe
- Mobile tap: production recipe
- Mobile double tap: usage recipe
- Mobile hold: tooltip/name

This makes the calculator more usable on Android/mobile browsers while keeping the original desktop behavior.