### PR TITLE
Bug Fix: Digester OC status

### DIFF
--- a/src/machines.ts
+++ b/src/machines.ts
@@ -1191,7 +1191,7 @@ machines["Industrial Wire Factory"] = {
 };
 
 machines["Digester"] = {
-    overclocker: StandardOverclocker.onlyNormal(),
+    overclocker: StandardOverclocker.onlyPerfect(),
     speed: 1,
     power: 1,
     parallels: 1,


### PR DESCRIPTION
Simple config change. Digester is a perfect OC block.

<img width="535" height="200" alt="image" src="https://github.com/user-attachments/assets/f2ed4ba0-e8db-44b7-b4ea-dbe0aa3aee6c" />
